### PR TITLE
Fix: property ignoreSSL should be checked for null when unchecked

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,1 @@
-This is a fork of original [TeamCity plugin](https://github.com/milgner/TeamCityRedmine)  which provides
-integration with [Redmine](http://www.redmine.org/) issue tracker.
-The fork makes the plugin compatible with TeamCity 9.1 (and incompatible with previous TeamCity versions).
-
-[Builds of this fork](https://teamcity.jetbrains.com/viewLog.html?buildTypeId=TeamCityRedminePlugin_Fork_BuildAgainstTeamCity91x&buildId=lastPinned): ![](https://teamcity.jetbrains.com/app/rest/builds/buildType:TeamCityRedminePlugin_Fork_BuildAgainstTeamCity91x/statusIcon) 
+This is a fork of [TeamCity 9.1 plugin] (https://github.com/orybak/TeamCityRedmine), a fork of original [TeamCity plugin](https://github.com/milgner/TeamCityRedmine) which fixes a small issue with TeamCity (version 9.1.7 at least) when ignoreSSL checkbox is unchecked.

--- a/redmine-server/src/main/java/com/marcusilgner/redcity/RedmineIssueProvider.java
+++ b/redmine-server/src/main/java/com/marcusilgner/redcity/RedmineIssueProvider.java
@@ -28,7 +28,7 @@ public class RedmineIssueProvider extends AbstractIssueProvider {
             fetcher.setPattern(result);
             fetcher.setApiToken(properties.get("apiToken"));
             String ignoreVal = properties.get("ignoreSSL");
-            fetcher.ignoreSSL(ignoreVal.equals("true"));
+            fetcher.ignoreSSL(ignoreVal != null && ignoreVal.equals("true"));
         }
         return result;
     }


### PR DESCRIPTION
I hope you would incorporate this property check for ignoreSSL.
Without this fix, unchecked ignoreSSL raises null-pointer exception in compilePattern(...) at least for TeamCity 9.1.7 we are currently testing with.
