### PR TITLE
Fix: property ignoreSSL should be checked for null when checkbox is unchecked (2)

### DIFF
--- a/redmine-server/src/main/java/com/marcusilgner/redcity/RedmineIssueProvider.java
+++ b/redmine-server/src/main/java/com/marcusilgner/redcity/RedmineIssueProvider.java
@@ -28,7 +28,7 @@ public class RedmineIssueProvider extends AbstractIssueProvider {
             fetcher.setPattern(result);
             fetcher.setApiToken(properties.get("apiToken"));
             String ignoreVal = properties.get("ignoreSSL");
-            fetcher.ignoreSSL(ignoreVal.equals("true"));
+            fetcher.ignoreSSL(ignoreVal != null && ignoreVal.equals("true"));
         }
         return result;
     }


### PR DESCRIPTION
I hope you would incorporate this property check for ignoreSSL.
Without this fix, unchecked ignoreSSL raises null-pointer exception in compilePattern(...) at least for TeamCity 9.1.7 we are currently testing with.
